### PR TITLE
specify deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   "author": "Ev Bogue <ev@evbogue.com>",
   "license": "MIT",
   "dependencies": {
-    "chalk": "",
-    "pull-stream": "",
-    "ssb-client": ""
+    "chalk": "^1.1.3",
+    "moment": "^2.13.0",
+    "pull-stream": "^3.4.2",
+    "ssb-client": "^3.1.1"
   }
 }


### PR DESCRIPTION
you where missing a dep... and the others weren't specified. you shouldn't do it like that because it will break when someone publishes a breaking change. (but if you specify deps correctly, then you'll still get the old versions, so it should be okay)

the simplest is to do `npm install <module> -S` and that will update the `package.json` for you.